### PR TITLE
Use correct lower bound for hedgehog dependency

### DIFF
--- a/hspec-hedgehog.cabal
+++ b/hspec-hedgehog.cabal
@@ -29,7 +29,7 @@ library
       base          >= 4.7   && < 5
     , hspec         >= 2.4.4 && < 3
     , hspec-core    >= 2.4.4 && < 3
-    , hedgehog      >= 1.0   && < 2
+    , hedgehog      >= 1.0.2 && < 2
     , HUnit         >= 1.5   && < 2
     , QuickCheck    >= 2.9.2 && < 3
     , splitmix      >= 0.0.1 && < 1
@@ -43,8 +43,8 @@ test-suite hspec-hedgehog-test
       test
   ghc-options: -threaded -rtsopts -with-rtsopts=-N
   build-depends:
-      base >=4.7 && <5
+      base          >= 4.7   && < 5
     , hspec-hedgehog
     , hspec
-    , hedgehog
+    , hedgehog      >= 1.0.2 && < 2
   default-language: Haskell2010


### PR DESCRIPTION
Fixes https://github.com/parsonsmatt/hspec-hedgehog/issues/5.

Not sure if this warrants a patch version bump. Happy to make that change if that's the case.