### PR TITLE
Handle errors better

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,12 @@
 # Changelog for hspec-hedgehog
 
+## 0.0.1.2
+
+- [#7](https://github.com/parsonsmatt/hspec-hedgehog/pull/7) @parsonsmatt
+    - Handle error states better by returning them in the instance rather than throwing an exception.
+- [#6](https://github.com/parsonsmatt/hspec-hedgehog/pull/6) @jezen
+    - Bump lower bound on `hedgehog` to fix the build constraints.
+
 ## 0.0.1.1
 
 - [#2](https://github.com/parsonsmatt/hspec-hedgehog/pull/2) @lehins

--- a/hspec-hedgehog.cabal
+++ b/hspec-hedgehog.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 name:           hspec-hedgehog
-version:        0.0.1.1
+version:        0.0.1.2
 description:    Please see the README on GitHub at <https://github.com/parsonsmatt/hspec-hedgehog#readme>
 synopsis:       Integrate Hedgehog and Hspec!
 category:       Testing


### PR DESCRIPTION
Rather than using `assertFailure` which throws an IO exception with the failure, this returns it from the IORef.