### PR TITLE
Use `m ~ IO` to improve type inference

### DIFF
--- a/src/Test/Hspec/Hedgehog.hs
+++ b/src/Test/Hspec/Hedgehog.hs
@@ -142,8 +142,8 @@ hedgehog = id
 -- of 'Example' for a function for more details.
 --
 -- @since 0.0.0.0
-instance Example (PropertyT IO ()) where
-    type Arg (PropertyT IO ()) = ()
+instance m ~ IO => Example (PropertyT m ()) where
+    type Arg (PropertyT m ()) = ()
     evaluateExample e = evaluateExample (\() -> e)
 
 -- | Warning: orphan instance! This instance is used to embed a "Hedgehog"

--- a/src/Test/Hspec/Hedgehog.hs
+++ b/src/Test/Hspec/Hedgehog.hs
@@ -155,8 +155,8 @@ instance Example (PropertyT IO ()) where
 -- Hedgehog tests.
 --
 -- @since 0.0.0.0
-instance Example (a -> PropertyT IO ()) where
-    type Arg (a -> PropertyT IO ()) = a
+instance (m ~ IO) => Example (a -> PropertyT m ()) where
+    type Arg (a -> PropertyT m ()) = a
 
     evaluateExample (fmap property -> aprop) params aroundAction progressCallback = do
         ref <- newIORef (Result "" (Pending Nothing Nothing))

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -23,6 +23,11 @@ main = hspec $ do
             x <- forAll $ Gen.integral (Range.linear 0 1000)
             y <- forAll $ Gen.integral (Range.linear 0 5000)
             diff (x + y) (>=) (x :: Integer)
+            
+        it "lets you use PropertyT directly without forcing the type" $ do
+            x <- forAll $ Gen.integral (Range.linear 0 1000)
+            y <- forAll $ Gen.integral (Range.linear 0 5000)
+            diff (x + y) (>=) (x :: Integer)
 
         it "renders a progress bit" $ hedgehog $ do
             x <- forAll $ Gen.integral (Range.linear 0 1000)


### PR DESCRIPTION
Currently, one has to use the `hedgehog` identity function to force the type of the test to be `PropertyT IO ()`. A better way to do this is to instead use an equality constraint in the instance head. This means that when we typecheck `it` we encounter `PropertyT m ()` as before, but we're now able to find an instance that matches. Refining the context will the force `m` to be `IO` and everything works out fine.