### PR TITLE
Show number of successful tests, classification + better gave up message

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,6 +1,6 @@
 # Changelog for hspec-hedgehog
 
-## 0.2.0.0
+## 0.1.1.0
 - [#30](https://github.com/parsonsmatt/hspec-hedgehog/pull/30) @sol
     - Show classification on success
     - Provide more information on "gave up"

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,10 @@
 # Changelog for hspec-hedgehog
 
+## 0.2.0.0
+- [#30](https://github.com/parsonsmatt/hspec-hedgehog/pull/30) @sol
+    - Show classification on success
+    - Provide more information on "gave up"
+
 ## 0.1.0.0
 
 - [#25](https://github.com/parsonsmatt/hspec-hedgehog/pull/25) @sol

--- a/hspec-hedgehog.cabal
+++ b/hspec-hedgehog.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 name:           hspec-hedgehog
-version:        0.2.0.0
+version:        0.1.1.0
 description:    Please see the README on GitHub at <https://github.com/parsonsmatt/hspec-hedgehog#readme>
 synopsis:       Integrate Hedgehog and Hspec!
 category:       Testing

--- a/hspec-hedgehog.cabal
+++ b/hspec-hedgehog.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 name:           hspec-hedgehog
-version:        0.1.0.0
+version:        0.2.0.0
 description:    Please see the README on GitHub at <https://github.com/parsonsmatt/hspec-hedgehog#readme>
 synopsis:       Integrate Hedgehog and Hspec!
 category:       Testing

--- a/src/Test/Hspec/Hedgehog.hs
+++ b/src/Test/Hspec/Hedgehog.hs
@@ -1,11 +1,13 @@
 {-# LANGUAGE FlexibleContexts      #-}
 {-# LANGUAGE FlexibleInstances     #-}
 {-# LANGUAGE InstanceSigs          #-}
+{-# LANGUAGE OverloadedStrings     #-}
 {-# LANGUAGE PartialTypeSignatures #-}
 {-# LANGUAGE RankNTypes            #-}
 {-# LANGUAGE RecordWildCards       #-}
 {-# LANGUAGE ScopedTypeVariables   #-}
 {-# LANGUAGE TypeFamilies          #-}
+{-# LANGUAGE TypeOperators         #-}
 {-# LANGUAGE TypeSynonymInstances  #-}
 {-# LANGUAGE ViewPatterns          #-}
 
@@ -102,7 +104,8 @@ import           Hedgehog.Internal.Property (DiscardLimit (..), Property (..),
                                              ShrinkLimit (..),
                                              TerminationCriteria (..),
                                              TestCount (..), TestLimit (..))
-import           Hedgehog.Internal.Report   as Hedge
+import           Hedgehog.Internal.Report   hiding (renderResult)
+import qualified Hedgehog.Internal.Report   as Hedge
 import           Hedgehog.Internal.Runner   (checkReport)
 import qualified Hedgehog.Internal.Seed     as Seed
 import           Hedgehog.Internal.Source   (ColumnNo (..), LineNo (..),
@@ -199,9 +202,12 @@ instance (m ~ IO) => Example (a -> PropertyT m ()) where
                Nothing       -> Seed.random
                Just (rng, _) -> pure (uncurry Seed (unseedSMGen (coerce rng)))
             hedgeResult <- checkReport propConfig size seed (propertyTest prop) cb
-            ppresult <- renderResult EnableColor Nothing hedgeResult
-            writeIORef ref $ Result "" $ case reportStatus hedgeResult of
-                Failed FailureReport{..} ->
+
+            let renderResult color = Hedge.renderResult color (Just "property") hedgeResult
+
+            case reportStatus hedgeResult of
+                Failed FailureReport{..} -> do
+                    ppresult <- renderResult EnableColor
                     let
                         fromSpan Span{..} =
                             Location
@@ -209,10 +215,11 @@ instance (m ~ IO) => Example (a -> PropertyT m ()) where
                                 , locationLine = coerce spanStartLine
                                 , locationColumn = coerce spanStartColumn
                                 }
-                    in
-                        Hspec.Failure (fromSpan <$> failureLocation) $ ColorizedReason ppresult
-                GaveUp ->
-                    Failure Nothing (Reason "GaveUp")
-                OK ->
-                    Success
+                    writeIORef ref $ Result "" $ Hspec.Failure (fromSpan <$> failureLocation) $ ColorizedReason ppresult
+                GaveUp -> do
+                    ppresult <- renderResult DisableColor
+                    writeIORef ref $ Result "" $ Failure Nothing (Reason ppresult)
+                OK -> do
+                    ppresult <- renderResult DisableColor
+                    writeIORef ref $ Result ppresult Success
         readIORef ref


### PR DESCRIPTION
# Before
![success before](https://github.com/parsonsmatt/hspec-hedgehog/assets/461132/a644043d-959d-447a-98f2-d4896419373b)
![gave-up before](https://github.com/parsonsmatt/hspec-hedgehog/assets/461132/fb5e3c7a-ac41-4ac6-9441-2f6f17a3d997)

# After
![success after](https://github.com/parsonsmatt/hspec-hedgehog/assets/461132/34384187-fb25-4800-bdc4-cd2ba00a9084)
![gave-up after](https://github.com/parsonsmatt/hspec-hedgehog/assets/461132/563c4d3d-5e4c-47bb-90ae-c5d84f3a4025)
