### PR TITLE
Tag and publish on version bumps

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,28 @@
+name: publish
+
+permissions:
+  contents: write
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - run: cabal check
+
+      - uses: sol/haskell-autotag@v1
+        id: autotag
+
+      - run: cabal sdist
+
+      - uses: haskell-actions/hackage-publish@v1.1
+        with:
+          hackageToken: ${{ secrets.HACKAGE_AUTH_TOKEN }}
+          publish: true
+        if: steps.autotag.outputs.created


### PR DESCRIPTION
@parsonsmatt this needs a `HACKAGE_AUTH_TOKEN`.  There are two options here:

1. Use the organization level `HACKAGE_AUTH_TOKEN`.
2. Use a repository level `HACKAGE_AUTH_TOKEN`.

## For option 1 please do the following:
- Add me, `SimonHengel`, to the Hackage maintainer group of this package at https://hackage.haskell.org/package/hspec-hedgehog/maintainers/edit

## For option 2 please do the following:
- Create a Hackage API token at https://hackage.haskell.org/user/parsonsmatt/manage
- Add that token as `HACKAGE_AUTH_TOKEN` at https://github.com/hspec/hspec-hedgehog/settings/secrets/actions/new