### PR TITLE
Fixed compilation errors on some architectures, such as riscv, arm, loongarch 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,8 +8,6 @@ on:
   pull_request:
     branches:
       - main
-  schedule:
-    - cron: 0 0 * * *
 
 jobs:
   build:

--- a/hspec-hedgehog.cabal
+++ b/hspec-hedgehog.cabal
@@ -47,7 +47,10 @@ test-suite spec
       Test.Hspec.HedgehogSpec
   hs-source-dirs:
       test
-  ghc-options: -threaded -rtsopts -with-rtsopts=-N
+  if arch(arm) || arch(mips) || arch(s390x) || arch(i386) || arch(riscv64) || arch(loongarch64)
+	  ghc-options: -threaded -rtsopts 
+  else
+	  ghc-options: -threaded -rtsopts -with-rtsopts=-N
   build-tool-depends:
       hspec-discover:hspec-discover
   build-depends:


### PR DESCRIPTION
Encountered an error while compiling in debian, the link to the error details is as follows: https://buildd.debian.org/status/fetch.php?pkg=haskell-hspec-hedgehog&arch=loong64&ver=0.0.1.2-5&stamp=1709414862&raw=0