### PR TITLE
Fix `propertyDiscardLimit`.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,10 @@
 # Changelog for hspec-hedgehog
 
+## 0.3.0.0
+
+- [#45](https://github.com/hspec/hspec-hedgehog/pull/45) @ChickenProp
+    - Set `propertyDiscardLimit` correctly.
+
 ## 0.2.0.0
  - [#29](https://github.com/parsonsmatt/hspec-hedgehog/pull/29) @sol
     - Show less context on failure.

--- a/src/Test/Hspec/Hedgehog.hs
+++ b/src/Test/Hspec/Hedgehog.hs
@@ -184,7 +184,7 @@ instance (m ~ IO) => Example (a -> PropertyT m ()) where
                             NoConfidenceTermination (TestLimit _) ->
                                 NoConfidenceTermination (TestLimit maxTests)
                     , propertyDiscardLimit =
-                        DiscardLimit $ maxDiscardRatio qcArgs
+                        DiscardLimit $ maxDiscardRatio qcArgs * maxTests
                     , propertyShrinkLimit =
                         ShrinkLimit $ maxShrinks qcArgs
                     }

--- a/test/Test/Hspec/HedgehogSpec.hs
+++ b/test/Test/Hspec/HedgehogSpec.hs
@@ -68,7 +68,7 @@ spec = do
     context "on Failure" $ do
       it "includes the number of discarded tests" $ do
         eval discard `shouldReturn` Result "" (Failure Nothing (Reason
-            "gave up after 10 discards, passed 0 tests.\n"
+            "gave up after 1000 discards, passed 0 tests.\n"
           ))
 
       it "provides a detailed failure message" $ do


### PR DESCRIPTION
QuickCheck has a [max discard ratio][1], i.e. a max value for `numDiscardedTests/maxSuccessTests`. Hedgehog just has an absolute discard count. So to bring them in line, we multiply max discard ratio by max successful tests.

Nitpick: if quickcheck runs more than `maxSuccessTests` successful tests for some reason (maybe coverage?) then it uses the current number of successful tests. Hedehog is also capable of running more than the naive maximum. In that case, it won't increase the discard limit.

The default quickcheck args are 100 successes and a discard ratio of 10. So if quickcheck has seen 200 successes, it'll allow up to 2000 discards. But if hedgehog has seen 200 successes, it'll still only allow up to 1000 disards.

[1]: https://github.com/nick8325/quickcheck/blob/f43aead829566f10aa3ef7c630351ed5918b3cc0/src/Test/QuickCheck/Test.hs#L325C1-L325C128